### PR TITLE
fix: update release-please workflow to use PROJECT_APP_PRIVATE_KEY secret

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,4 +10,4 @@ jobs:
   release:
     uses: GersonRS/modern-gitops-stack/.github/workflows/modules-release-please.yaml@main
     secrets:
-      PAT: ${{ secrets.PAT }}
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Changes

- Fix release-please workflow to use `PROJECT_APP_PRIVATE_KEY` secret instead of deprecated `PAT`