### PR TITLE
feat: add gateway_name and gateway_namespace variables for Istio compatibility

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -10,4 +10,4 @@ jobs:
   release:
     uses: GersonRS/modern-gitops-stack/.github/workflows/modules-release-please.yaml@main
     secrets:
-      PAT: ${{ secrets.PAT }}
+      PROJECT_APP_PRIVATE_KEY: ${{ secrets.PROJECT_APP_PRIVATE_KEY }}

--- a/variables.tf
+++ b/variables.tf
@@ -109,3 +109,15 @@ variable "resources" {
   })
   default = {}
 }
+
+variable "gateway_name" {
+  description = "Name of the Istio Gateway resource to attach the HTTPRoute to."
+  type        = string
+  default     = "istio-gateway"
+}
+
+variable "gateway_namespace" {
+  description = "Namespace of the Istio Gateway resource."
+  type        = string
+  default     = "istio-ingress"
+}


### PR DESCRIPTION
Add `gateway_name` and `gateway_namespace` variables for Istio Gateway API compatibility. Strimzi is the Kafka operator and has no HTTP endpoint to expose, but variables are added for consistency with other modules.